### PR TITLE
Fix sidebar collapse bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
              *
              * enable toggleNavClasses in mobile
              */
-            if (document.getElementById('menu').style.display !== 'none') {
+            if (getComputedStyle(document.getElementById('menu'), null).display !== 'none') {
               toggleNavClasses();
 
               document.getElementById('iframe_a').addEventListener("load", function() {


### PR DESCRIPTION
# The bug

When you first load a page on https://predixdev.github.io/predix-ui/ and drag the window smaller to test responsiveness, the sidebar menu will automatically collapse on small screens. However, if you click a link to another page in the sidebar and attempt to shrink the window again, the menu will no longer be hidden automatically. See the gif below.

![px-menu-gif](https://cloud.githubusercontent.com/assets/6456757/18490233/f01333d4-79b5-11e6-98f6-7075a399448e.gif)
# What’s happening

When a sidebar link is clicked, we want to re-render the page by pushing state. In the same function that changes state, we also do a dirty check to see if we’re on a small screen by checking if an element with the ID `#menu` is visible. `#menu` is a toggle button that’s hidden on large screens with media queries in css.

 `#menu`’s visibility is currently checked like this:

```
if (document.getElementById('menu').style.display !== 'none') {
    toggleNavClasses();
}
```

This function is always returning `true` (i.e. elem.style.display is not the string ‘none’) because `#menu` inherits its display from the CSS class .menu. (I think checking it like this would work if there was a style=“display:none;” set inline on the tag.)
# The fix

Instead of checking the style property of the element, we can use `getComputedStyle` to see what styles this element inherits. Now, this should work:

```
if (getComputedStyle(document.getElementById('menu'), null).display !== 'none') {
    toggleNavClasses();
}
```

And the toggle behavior should work like we expect.

/cc @Menkhaus-ge @randyaskin for your review
