### PR TITLE
fix vis expansion issue

### DIFF
--- a/elements/px-catalog/pages.json
+++ b/elements/px-catalog/pages.json
@@ -1541,7 +1541,7 @@
         "label": "Data Visualization",
         "pages": [
           {
-            "path": "px-vis",
+            "path": "px-vis-framework",
             "label": "Vis Framework",
             "keywords": [
               "px-vis",
@@ -1555,13 +1555,14 @@
             ],
             "pages": [
               {
-                "path": "px-vis",
+                "path": "px-vis-catalog",
                 "label": "Vis Framework",
                 "module": "px-vis-catalog",
                 "entrypoint": "/bower_components/px-vis/demo/px-vis-catalog.html",
                 "redirects": [
                   "/components/px-vis",
-                  "/modules/px-vis"
+                  "/modules/px-vis",
+                  "/elements/vis/px-vis/px-vis"
                 ],
                 "keywords": [
                   "px-vis-catalog",
@@ -1587,7 +1588,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-area-svg",
-                  "/modules/px-vis-area-svg"
+                  "/modules/px-vis-area-svg",
+                  "/elements/vis/px-vis/px-vis-area-svg"
                 ],
                 "subcomponent": true
               },
@@ -1602,7 +1604,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-axis",
-                  "/modules/px-vis-axis"
+                  "/modules/px-vis-axis",
+                  "/elements/vis/px-vis/px-vis-axis"
                 ],
                 "subcomponent": true
               },
@@ -1617,7 +1620,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-axis-interaction-space",
-                  "/modules/px-vis-axis-interaction-space"
+                  "/modules/px-vis-axis-interaction-space",
+                  "/elements/vis/px-vis/px-vis-axis-interaction-space"
                 ],
                 "subcomponent": true
               },
@@ -1632,7 +1636,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-bar-svg",
-                  "/modules/px-vis-bar-svg"
+                  "/modules/px-vis-bar-svg",
+                  "/elements/vis/px-vis/px-vis-bar-svg"
                 ],
                 "subcomponent": true
               },
@@ -1647,7 +1652,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-brush",
-                  "/modules/px-vis-brush"
+                  "/modules/px-vis-brush",
+                  "/elements/vis/px-vis/px-vis-brush"
                 ],
                 "subcomponent": true
               },
@@ -1662,7 +1668,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-canvas",
-                  "/modules/px-vis-canvas"
+                  "/modules/px-vis-canvas",
+                  "/elements/vis/px-vis/px-vis-canvas"
                 ],
                 "subcomponent": true
               },
@@ -1677,7 +1684,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-chart-navigator",
-                  "/modules/px-vis-chart-navigator"
+                  "/modules/px-vis-chart-navigator",
+                  "/elements/vis/px-vis/px-vis-chart-navigator"
                 ],
                 "subcomponent": true
               },
@@ -1692,7 +1700,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-clip-path",
-                  "/modules/px-vis-clip-path"
+                  "/modules/px-vis-clip-path",
+                  "/elements/vis/px-vis/px-vis-clip-path"
                 ],
                 "subcomponent": true
               },
@@ -1707,7 +1716,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-clip-path-complex-area",
-                  "/modules/px-vis-clip-path-complex-area"
+                  "/modules/px-vis-clip-path-complex-area",
+                  "/elements/vis/px-vis/px-vis-clip-path-complex-area"
                 ],
                 "subcomponent": true
               },
@@ -1722,7 +1732,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-cursor",
-                  "/modules/px-vis-cursor"
+                  "/modules/px-vis-cursor",
+                  "/elements/vis/px-vis/px-vis-cursor"
                 ],
                 "subcomponent": true
               },
@@ -1737,7 +1748,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-cursor-line",
-                  "/modules/px-vis-cursor-line"
+                  "/modules/px-vis-cursor-line",
+                  "/elements/vis/px-vis/px-vis-cursor-line"
                 ],
                 "subcomponent": true
               },
@@ -1752,7 +1764,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-data-converter",
-                  "/modules/px-vis-data-converter"
+                  "/modules/px-vis-data-converter",
+                  "/elements/vis/px-vis/px-vis-data-converter"
                 ],
                 "subcomponent": true
               },
@@ -1767,7 +1780,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-dynamic-menu",
-                  "/modules/px-vis-dynamic-menu"
+                  "/modules/px-vis-dynamic-menu",
+                  "/elements/vis/px-vis/px-vis-dynamic-menu"
                 ],
                 "subcomponent": true
               },
@@ -1782,7 +1796,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-event",
-                  "/modules/px-vis-event"
+                  "/modules/px-vis-event",
+                  "/elements/vis/px-vis/px-vis-event"
                 ],
                 "subcomponent": true
               },
@@ -1797,7 +1812,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-gridlines",
-                  "/modules/px-vis-gridlines"
+                  "/modules/px-vis-gridlines",
+                  "/elements/vis/px-vis/px-vis-gridlines"
                 ],
                 "subcomponent": true
               },
@@ -1812,7 +1828,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-highlight-line-canvas",
-                  "/modules/px-vis-highlight-line-canvas"
+                  "/modules/px-vis-highlight-line-canvas",
+                  "/elements/vis/px-vis/px-vis-highlight-line-canvas"
                 ],
                 "subcomponent": true
               },
@@ -1827,7 +1844,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-highlight-line",
-                  "/modules/px-vis-highlight-line"
+                  "/modules/px-vis-highlight-line",
+                  "/elements/vis/px-vis/px-vis-highlight-line"
                 ],
                 "subcomponent": true
               },
@@ -1842,7 +1860,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-highlight-point-canvas",
-                  "/modules/px-vis-highlight-point-canvas"
+                  "/modules/px-vis-highlight-point-canvas",
+                  "/elements/vis/px-vis/px-vis-highlight-point-canvas"
                 ],
                 "subcomponent": true
               },
@@ -1857,7 +1876,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-highlight-point",
-                  "/modules/px-vis-highlight-point"
+                  "/modules/px-vis-highlight-point",
+                  "/elements/vis/px-vis/px-vis-highlight-point"
                 ],
                 "subcomponent": true
               },
@@ -1872,7 +1892,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-interactive-axis",
-                  "/modules/px-vis-interactive-axis"
+                  "/modules/px-vis-interactive-axis",
+                  "/elements/vis/px-vis/px-vis-interactive-axis"
                 ],
                 "subcomponent": true
               },
@@ -1887,7 +1908,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-interaction-space",
-                  "/modules/px-vis-interaction-space"
+                  "/modules/px-vis-interaction-space",
+                  "/elements/vis/px-vis/px-vis-interaction-space"
                 ],
                 "subcomponent": true
               },
@@ -1902,7 +1924,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-line-canvas",
-                  "/modules/px-vis-line-canvas"
+                  "/modules/px-vis-line-canvas",
+                  "/elements/vis/px-vis/px-vis-line-canvas"
                 ],
                 "subcomponent": true
               },
@@ -1917,7 +1940,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-line-svg",
-                  "/modules/px-vis-line-svg"
+                  "/modules/px-vis-line-svg",
+                  "/elements/vis/px-vis/px-vis-line-svg"
                 ],
                 "subcomponent": true
               },
@@ -1932,7 +1956,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-multi-axis",
-                  "/modules/px-vis-multi-axis"
+                  "/modules/px-vis-multi-axis",
+                  "/elements/vis/px-vis/px-vis-multi-axis"
                 ],
                 "subcomponent": true
               },
@@ -1947,7 +1972,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-multi-scale",
-                  "/modules/px-vis-multi-scale"
+                  "/modules/px-vis-multi-scale",
+                  "/elements/vis/px-vis/px-vis-multi-scale"
                 ],
                 "subcomponent": true
               },
@@ -1963,7 +1989,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-pie",
-                  "/modules/px-vis-pie"
+                  "/modules/px-vis-pie",
+                  "/elements/vis/px-vis/px-vis-pie"
                 ],
                 "subcomponent": true
               },
@@ -1978,7 +2005,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-radar-grid",
-                  "/modules/px-vis-radar-grid"
+                  "/modules/px-vis-radar-grid",
+                  "/elements/vis/px-vis/px-vis-radar-grid"
                 ],
                 "subcomponent": true
               },
@@ -1993,7 +2021,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-radial-gridlines",
-                  "/modules/px-vis-radial-gridlines"
+                  "/modules/px-vis-radial-gridlines",
+                  "/elements/vis/px-vis/px-vis-radial-gridlines"
                 ],
                 "subcomponent": true
               },
@@ -2008,7 +2037,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-radial-scale",
-                  "/modules/px-vis-radial-scale"
+                  "/modules/px-vis-radial-scale",
+                  "/elements/vis/px-vis/px-vis-radial-scale"
                 ],
                 "subcomponent": true
               },
@@ -2023,7 +2053,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-register",
-                  "/modules/px-vis-register"
+                  "/modules/px-vis-register",
+                  "/elements/vis/px-vis/px-vis-register"
                 ],
                 "subcomponent": true
               },
@@ -2038,7 +2069,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-scale",
-                  "/modules/px-vis-scale"
+                  "/modules/px-vis-scale",
+                  "/elements/vis/px-vis/px-vis-scale"
                 ],
                 "subcomponent": true
               },
@@ -2053,7 +2085,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-scatter",
-                  "/modules/px-vis-scatter"
+                  "/modules/px-vis-scatter",
+                  "/elements/vis/px-vis/px-vis-scatter"
                 ],
                 "subcomponent": true
               },
@@ -2068,7 +2101,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-scatter-canvas",
-                  "/modules/px-vis-scatter-canvas"
+                  "/modules/px-vis-scatter-canvas",
+                  "/elements/vis/px-vis/px-vis-scatter-canvas"
                 ],
                 "subcomponent": true
               },
@@ -2083,7 +2117,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-striping",
-                  "/modules/px-vis-striping"
+                  "/modules/px-vis-striping",
+                  "/elements/vis/px-vis/px-vis-striping"
                 ],
                 "subcomponent": true
               },
@@ -2098,7 +2133,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-svg",
-                  "/modules/px-vis-svg"
+                  "/modules/px-vis-svg",
+                  "/elements/vis/px-vis/px-vis-svg"
                 ],
                 "subcomponent": true
               },
@@ -2113,7 +2149,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-svg-canvas",
-                  "/modules/px-vis-svg-canvas"
+                  "/modules/px-vis-svg-canvas",
+                  "/elements/vis/px-vis/px-vis-svg-canvas"
                 ],
                 "subcomponent": true
               },
@@ -2128,7 +2165,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-threshold",
-                  "/modules/px-vis-threshold"
+                  "/modules/px-vis-threshold",
+                  "/elements/vis/px-vis/px-vis-threshold"
                 ],
                 "subcomponent": true
               },
@@ -2143,7 +2181,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-toolbar",
-                  "/modules/px-vis-toolbar"
+                  "/modules/px-vis-toolbar",
+                  "/elements/vis/px-vis/px-vis-toolbar"
                 ],
                 "subcomponent": true
               },
@@ -2158,7 +2197,8 @@
                 ],
                 "redirects": [
                   "/components/px-vis-tooltip",
-                  "/modules/px-vis-tooltip"
+                  "/modules/px-vis-tooltip",
+                  "/elements/vis/px-vis/px-vis-tooltip"
                 ],
                 "subcomponent": true
               }


### PR DESCRIPTION
Alternatively we could alter the `_isInSelectedRoute` method, but basically the issue is that `elements/vis/px-vis/px-vis` is a match with `elements/vis/px-vis/px-vis-parallel-coordinates` etc, so this change makes the paths a bit different so they're unique.