### PR TITLE
CLA jump nav fixes

### DIFF
--- a/_pages/develop/cla.html
+++ b/_pages/develop/cla.html
@@ -14,8 +14,9 @@
 
 <dom-module id="dev-cla">
   <template>
-    <style include="px-catalog-theme-styles px-catalog-page-styles"></style>
     <style include="px-cla-styles"></style>
+    <style include="px-catalog-theme-styles px-catalog-page-styles"></style>
+
     <px-notification
       id="form-feedback-notification"
       class="cla__notification">
@@ -204,6 +205,7 @@
       }
       constructor() {
         super();
+        this.is = 'dev-cla';
         Polymer.RenderStatus.afterNextRender(this, () => {
           // Initialize Firebase
           var config = {


### PR DESCRIPTION
The `this.is` in the constructor fixes the jump nav scrolling behavior for the page.

Moving the style imports makes sure the px-cla styles don't override the page styles for the jump nav and make all a links blue. jump nav links should be gray when they are not active.

