### PR TITLE
Fixed px-data-table 404 on predix-ui.com

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/px-data-table/px-data-table https://predix-ui.github.io/px-data-table/px-data-table 302

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -238,6 +238,11 @@ gulp.task('polymerBuild', function (cb) {
 
 });
 
+gulp.task('copy-netlify-cfg', (cb) => {
+  fs.copyFileSync('_redirects', `${localBuildFolder}/_redirects`);
+  cb();
+})
+
 /*******************************************************************************
  * LOCAL BUILD PIPELINE
  *
@@ -256,7 +261,7 @@ gulp.task('localBuild', function(callback) {
  ******************************************************************************/
 
 gulp.task('prodBuild', function(callback) {
-   gulpSequence('generate-api', 'sass', 'docs', 'gallery-json', 'build-polymer-scripts', 'polymerBuild', 'generate-service-worker')(callback);
+   gulpSequence('generate-api', 'sass', 'docs', 'gallery-json', 'build-polymer-scripts', 'polymerBuild', 'generate-service-worker', 'copy-netlify-cfg')(callback);
 });
 
 /*******************************************************************************


### PR DESCRIPTION
The link to px-data-table on predix-ui.com currently 404s. This is a quick workaround until I work how to solve this problem properly on the netlify-served predix-ui.com.

The deployment preview won't show the change, as px-data-table links directly to predix-ui.com (the netlify preview uses a different domain)