### PR TITLE
Disable all tracking (google analytics, etc) for GDPR compliance

### DIFF
--- a/elements/px-catalog/px-catalog.html
+++ b/elements/px-catalog/px-catalog.html
@@ -483,6 +483,8 @@
        * @param  {object} details   - Object with event metadata to use later in analysis
        */
       window.TrackEvent = function(eventName, details) {
+        // Disable all tracking for now until GDPR compliant
+        return;
         if (failedEvents >= 2) {
           // Too many failures, stop sending events for this session
           return;

--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
 
     <link rel="preload" href="bower_components/px-typography-design/type/GEInspiraSans.woff2" as="font" type="font/woff2" crossorigin/>
     <link rel="preload" href="bower_components/px-typography-design/type/GEInspiraSans-Bold.woff2" as="font" type="font/woff2" crossorigin/>
-    <link rel="preconnect" href="https://www.google-analytics.com/"/>
 
     <script async type="text/javascript" src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
     <link async rel="import" href="bower_components/px-theme/px-theme-local-fonts-styles.html"/>
@@ -91,13 +90,6 @@
 
     <!-- Elements wait on the page and are upgraded after elements.html is loaded. -->
     <px-catalog></px-catalog>
-
-    <script>
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', 'UA-80996379-1', 'auto');
-    ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     <!-- Load service worker -->
     <script async src="service-worker-registration.js"></script>


### PR DESCRIPTION
Current analytics configuration is not GDPR complaint. I've removed all tracking until we've regained control of GA account and can reconfigure it to align with the auditor's recommendations.